### PR TITLE
Mojolicious and Mojolicious::Plugin::OpenAPI updates to contemporary versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Open `openapi.conf` and insert the following _snippet_:
     "swagger": "2.0",
     "info": { "version": "1.0", "title": "Hello World example" },
     "basePath": "/api",
+    "produces": ["application/json"],
     "paths": {
       "/hello_world": {
         "get": {
@@ -98,6 +99,8 @@ Now lets go over our definiton.
 - `x-mojo-name`: this is the name used to identify our operation in the **Mojolicious** application
 
 - `x-mojo-to`: this is the specification for the route to be used for our operation in the **Mojolicious** application, more on this later
+
+- `produces`: declares the MIME types the API can return. Newer versions of `Mojolicious::Plugin::OpenAPI` validate the incoming `Accept` header against this list. Without it, a request with `Accept: */*` will be rejected with a 400 error.
 
 - `responses`: here we define the type we want to handle, for now we settle for `200`. The response definition outline our response, this could be boiled down to a `string` instead of an `object`, with properties, but the example would be come _too simple_ and in my opinion we work primarily with objects over basic types, so this extended example makes for a better reference.
 

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -1,32 +1,38 @@
 # carton snapshot format: version 1.0
 DISTRIBUTIONS
-  JSON-Validator-4.05
-    pathname: J/JH/JHTHORSEN/JSON-Validator-4.05.tar.gz
+  JSON-Validator-5.15
+    pathname: J/JH/JHTHORSEN/JSON-Validator-5.15.tar.gz
     provides:
-      JSON::Validator 4.05
+      JSON::Validator 5.15
       JSON::Validator::Error undef
+      JSON::Validator::Exception undef
       JSON::Validator::Formats undef
       JSON::Validator::Joi undef
-      JSON::Validator::Ref undef
       JSON::Validator::Schema undef
+      JSON::Validator::Schema::Draft201909 undef
       JSON::Validator::Schema::Draft4 undef
       JSON::Validator::Schema::Draft6 undef
       JSON::Validator::Schema::Draft7 undef
+      JSON::Validator::Schema::OpenAPIv2 undef
+      JSON::Validator::Schema::OpenAPIv3 undef
+      JSON::Validator::Store undef
+      JSON::Validator::URI undef
       JSON::Validator::Util undef
     requirements:
       ExtUtils::MakeMaker 0
       List::Util 1.45
       Mojolicious 7.28
       YAML::XS 0.67
-      perl 5.010001
-  Mojolicious-8.61
-    pathname: S/SR/SRI/Mojolicious-8.61.tar.gz
+      perl 5.016
+  Mojolicious-9.42
+    pathname: S/SR/SRI/Mojolicious-9.42.tar.gz
     provides:
       Mojo undef
       Mojo::Asset undef
       Mojo::Asset::File undef
       Mojo::Asset::Memory undef
       Mojo::Base undef
+      Mojo::BaseUtil undef
       Mojo::ByteStream undef
       Mojo::Cache undef
       Mojo::Collection undef
@@ -49,7 +55,6 @@ DISTRIBUTIONS
       Mojo::Home undef
       Mojo::IOLoop undef
       Mojo::IOLoop::Client undef
-      Mojo::IOLoop::Delay undef
       Mojo::IOLoop::Server undef
       Mojo::IOLoop::Stream undef
       Mojo::IOLoop::Subprocess undef
@@ -67,6 +72,7 @@ DISTRIBUTIONS
       Mojo::Reactor undef
       Mojo::Reactor::EV undef
       Mojo::Reactor::Poll undef
+      Mojo::SSE undef
       Mojo::Server undef
       Mojo::Server::CGI undef
       Mojo::Server::Daemon undef
@@ -89,11 +95,12 @@ DISTRIBUTIONS
       Mojo::UserAgent::Transactor undef
       Mojo::Util undef
       Mojo::WebSocket undef
-      Mojolicious 8.61
+      Mojolicious 9.42
       Mojolicious::Command undef
       Mojolicious::Command::Author::cpanify undef
       Mojolicious::Command::Author::generate undef
       Mojolicious::Command::Author::generate::app undef
+      Mojolicious::Command::Author::generate::dockerfile undef
       Mojolicious::Command::Author::generate::lite_app undef
       Mojolicious::Command::Author::generate::makefile undef
       Mojolicious::Command::Author::generate::plugin undef
@@ -111,6 +118,7 @@ DISTRIBUTIONS
       Mojolicious::Lite undef
       Mojolicious::Plugin undef
       Mojolicious::Plugin::Config undef
+      Mojolicious::Plugin::Config::Sandbox undef
       Mojolicious::Plugin::DefaultHelpers undef
       Mojolicious::Plugin::EPLRenderer undef
       Mojolicious::Plugin::EPRenderer undef
@@ -137,18 +145,19 @@ DISTRIBUTIONS
       IO::Socket::IP 0.37
       Sub::Util 1.41
       perl 5.016
-  Mojolicious-Plugin-OpenAPI-3.39
-    pathname: J/JH/JHTHORSEN/Mojolicious-Plugin-OpenAPI-3.39.tar.gz
+  Mojolicious-Plugin-OpenAPI-5.11
+    pathname: J/JH/JHTHORSEN/Mojolicious-Plugin-OpenAPI-5.11.tar.gz
     provides:
-      JSON::Validator::OpenAPI::Mojolicious undef
-      Mojolicious::Plugin::OpenAPI 3.39
+      Mojolicious::Plugin::OpenAPI 5.11
       Mojolicious::Plugin::OpenAPI::Cors undef
+      Mojolicious::Plugin::OpenAPI::Parameters undef
       Mojolicious::Plugin::OpenAPI::Security undef
       Mojolicious::Plugin::OpenAPI::SpecRenderer undef
     requirements:
       ExtUtils::MakeMaker 0
-      JSON::Validator 4.05
-      Mojolicious 8.00
+      JSON::Validator 5.13
+      Mojolicious 9.00
+      perl 5.016
   YAML-LibYAML-v0.906.0
     pathname: T/TI/TINITA/YAML-LibYAML-v0.906.0.tar.gz
     provides:
@@ -164,3 +173,9 @@ DISTRIBUTIONS
       perl 5.008001
       strict 0
       warnings 0
+  install-0.01
+    pathname: D/DA/DAGOLDEN/install-0.01.tar.gz
+    provides:
+      install 0.01
+    requirements:
+      ExtUtils::MakeMaker 0

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -17,7 +17,7 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       List::Util 1.45
       Mojolicious 7.28
-      YAML::PP 0.020
+      YAML::XS 0.67
       perl 5.010001
   Mojolicious-8.61
     pathname: S/SR/SRI/Mojolicious-8.61.tar.gz
@@ -111,7 +111,6 @@ DISTRIBUTIONS
       Mojolicious::Lite undef
       Mojolicious::Plugin undef
       Mojolicious::Plugin::Config undef
-      Mojolicious::Plugin::Config::Sandbox undef
       Mojolicious::Plugin::DefaultHelpers undef
       Mojolicious::Plugin::EPLRenderer undef
       Mojolicious::Plugin::EPRenderer undef
@@ -150,59 +149,18 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       JSON::Validator 4.05
       Mojolicious 8.00
-  YAML-PP-0.026
-    pathname: T/TI/TINITA/YAML-PP-0.026.tar.gz
+  YAML-LibYAML-v0.906.0
+    pathname: T/TI/TINITA/YAML-LibYAML-v0.906.0.tar.gz
     provides:
-      YAML::PP 0.026
-      YAML::PP::Common 0.026
-      YAML::PP::Constructor 0.026
-      YAML::PP::Dumper 0.026
-      YAML::PP::Emitter 0.026
-      YAML::PP::Exception 0.026
-      YAML::PP::Grammar 0.026
-      YAML::PP::Highlight 0.026
-      YAML::PP::Lexer 0.026
-      YAML::PP::Loader 0.026
-      YAML::PP::Parser 0.026
-      YAML::PP::Perl 0.026
-      YAML::PP::Preserve::Array 0.026
-      YAML::PP::Preserve::Hash 0.026
-      YAML::PP::Preserve::Scalar 0.026
-      YAML::PP::Reader 0.026
-      YAML::PP::Reader::File 0.026
-      YAML::PP::Render 0.026
-      YAML::PP::Representer 0.026
-      YAML::PP::Schema 0.026
-      YAML::PP::Schema::Binary 0.026
-      YAML::PP::Schema::Core 0.026
-      YAML::PP::Schema::Failsafe 0.026
-      YAML::PP::Schema::Include 0.026
-      YAML::PP::Schema::JSON 0.026
-      YAML::PP::Schema::Merge 0.026
-      YAML::PP::Schema::Perl 0.026
-      YAML::PP::Schema::Tie::IxHash 0.026
-      YAML::PP::Schema::YAML1_1 0.026
-      YAML::PP::Type::MergeKey 0.026
-      YAML::PP::Writer 0.026
-      YAML::PP::Writer::File 0.026
+      YAML::LibYAML v0.906.0
+      YAML::XS v0.906.0
     requirements:
-      B 0
       B::Deparse 0
-      Carp 0
-      Data::Dumper 0
-      Encode 0
       Exporter 0
       ExtUtils::MakeMaker 0
-      File::Basename 0
-      Getopt::Long 0
-      MIME::Base64 0
-      Module::Load 0
-      Scalar::Util 1.07
-      Tie::Array 0
-      Tie::Hash 0
+      Scalar::Util 0
       base 0
       constant 0
-      overload 0
-      perl 5.008000
+      perl 5.008001
       strict 0
       warnings 0

--- a/openapi.json
+++ b/openapi.json
@@ -2,6 +2,7 @@
     "swagger": "2.0",
     "info": { "version": "1.0", "title": "Hello World example" },
     "basePath": "/api",
+    "produces": ["application/json"],
     "paths": {
       "/hello_world": {
         "get": {


### PR DESCRIPTION
- **Updated Mojolicious to latest version, everything still works**
- **Patched the example and documentation after upgrading Mojolicious to version 9.42 (no regression observed and Mojolicious::Plugin::OpenAPI to version 5.11, which observed regression. The documentation and openapi.json has been patched with the missing section: produces**
- **Bumped Mojolicious and Mojolicious::Plugin::API after local install and test**
